### PR TITLE
Fix OpenCV/GStreamer installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 from setuptools import find_packages, setup
+import os
+
+try:
+    with open("README.md", "r", encoding="utf-8") as f:
+        long_description = f.read()
+except FileNotFoundError:
+    long_description = "Python package implementation for Siyi SDK."
 
 setup(
     name="siyi_sdk",
     version="0.1.0",
     description="Python package implementation for Siyi SDK.",
-    long_description=open("README.md").read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     author="Mohamed Abdelkader",
     author_email="mohamedashraf123@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author="Mohamed Abdelkader",
     author_email="mohamedashraf123@gmail.com",
     packages=find_packages(exclude=["*/test",".github"]),
-    install_requires=["opencv-python>=4.0.0", "imutils", "ffmpeg-python"],
+    install_requires=["imutils", "ffmpeg-python"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
#### **Overview**

This PR fixes the installation of OpenCV compatible with GStreamer through Autoproj and handles a FileNotFoundError when compiling the SDK with colcon build.

Defining OpenCV as an installation requirement in the "setup.py" file makes Autoproj install OpenCV through pip without support for GStreamer, even specifying the version. Removing it from the requirements makes Autoproj rely on the system OpenCV version, which supports GStreamer, and it's already installed during the workspace setup with Autoproj.

The original author of this SDK also recommended installing OpenCV and GStreamer plugins through apt.

GStreamer is an image streaming pipeline necessary to significantly reduce the streaming delay with SIYI camera. Without it, the image streaming falls back to FFMPEG pipeline, which results in too much delay.

#### **Use the following settings in the overrides file for docker testing**

- Use these settings to compile and run the module using `autoproj`.
- The contents of the files manifest and `overrides.yaml` must be changed according to the `templates` below.
- Additional packages may be needed to test this module.

  e.g.,

- _overrides.yaml_

  ```yaml
    overrides:
      - siyi_camera_driver:
        branch: fix/add-gstreamer
      - siyi_sdk:
        branch: fix/enable-gstreamer
  ```

- _manifest_

  ```yaml
      package_sets:
        - github: Brazilian-Institute-of-Robotics/python.base-package_set
          branch: main
          private: true
        - github: Brazilian-Institute-of-Robotics/ros2.colcon-package_set
          branch: main
          private: true
        - github: Brazilian-Institute-of-Robotics/ros2.distro-package_set
          branch: main
          private: true
        - github: Brazilian-Institute-of-Robotics/core_base-package_set
          branch: main
          private: true
        - github: Brazilian-Institute-of-Robotics/ros2.gazebo-package_set
          branch: main
          private: true
        - github: Brazilian-Institute-of-Robotics/commons_plugin_package_set
          private: true
          branch: main
        - github: Brazilian-Institute-of-Robotics/<package_name>_set
          branch: main
          private: true
      layout:
        - viper
        - siyi_sdk
  ```

#### **What was added/changed in this update**

- [Remove opencv dependency](https://github.com/Brazilian-Institute-of-Robotics/siyi_sdk/commit/332e617e8a7dd38ace573e13eeea8cff56b7a5dd)
- [Handle error when not founding README.md file](https://github.com/Brazilian-Institute-of-Robotics/siyi_sdk/pull/6/commits/941000388c31538d98f32c4f6378a75bbc9f43b0)

#### **Depends On:**

- [SIYI Driver PR #12](https://github.com/Brazilian-Institute-of-Robotics/siyi_camera_driver/pull/12)

#### **Related Issues:**

- N/A.

#### **Notes:**

- N/A.
